### PR TITLE
[버그수정] 썸네일 각도가 변경되는 현상 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,16 @@ dependencies {
     //쿼리에 ?내용 보여주기
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
 
-    //스프링mvc테스트 시, 관심상품등록하려면 로그인이 필요한데, 가짜로그인을 해주기 위해 필요.
+    //Spring security
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //메타데이터 정보 추출
+    implementation 'com.drewnoakes:metadata-extractor:2.9.1'
+    //사진 회전
+    implementation 'org.imgscalr:imgscalr-lib:4.2'
+
+
+
 }
 
 test {

--- a/src/main/java/com/sparta/backend/service/cafe/CafeService.java
+++ b/src/main/java/com/sparta/backend/service/cafe/CafeService.java
@@ -24,13 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
-import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.List;
@@ -187,9 +184,7 @@ public class CafeService {
 
         //섬네일 이미지 바꾸기
         CafeImage cafeImage = cafeImageRepository.findTopByCafe(cafe);
-        URL url = new URL(cafeImage.getImage());
-        Image image = ImageIO.read(url);
-        BufferedImage resizedImage = s3Uploader.resizeImage(image, 200, 200);
+        BufferedImage resizedImage = s3Uploader.resizeImage(cafeImage.getImage());
 
         File imageFile = new File(cafeImage.getImage());
         String savedThumbNailUrl = s3Uploader.uploadBufferedImageToS3(resizedImage,"thumbNail",imageFile);


### PR DESCRIPTION
- 카페후기 목록 조회 시 일부 썸네일이 돌아가있는 현상 해결
- 카페후기 작성 시 썸네일이 돌아가있는 현상은 해결했지만,
   기존에 올린 이미지 URL을 가지고 썸네일을 생성했을 때 썸네일이 돌아가있는 현상은 해결하지 못했음
   (이미지 URL을 파일로 변환했을 때 메타데이터가 없는 이유 때문인 것으로 추정)
   해결: 썸네일이 돌아가있는 게시물의 원본사진을 다운받아, 
            게시물 작성 API를 통해 각 게시물의 썸네일 URL을 얻어내 DB에서 직접 수정(: 노가다...)

어쩔 수 없었습니다..노가다 뛰어서라도 해결했으니 다행이라고 봅니다..